### PR TITLE
Added creation of uploadFile at the beginning of the script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ exports['default'] = () => {
 
     async reportTaskStart(startTime, userAgents, testCount) {
       console.log("reportTaskStart")
+      fs.writeFileSync(jiraUploadAllReportsPath, "", "utf8");
     },
 
     async reportFixtureStart(name: string, path: string, meta: JiraMetaData) {


### PR DESCRIPTION
This way the file will exist and won't throw a 'does not exist' error in the end if no meta data was used. Apparently the chmod does not have a check for file flag.